### PR TITLE
Fixed inconsistent date formatting in gallery modal due to automatic locale settings

### DIFF
--- a/src/components/gallerycomp/Modal.jsx
+++ b/src/components/gallerycomp/Modal.jsx
@@ -17,9 +17,9 @@ const Modal = ({ emotions, setIsUploaded, userID, myImages, selectedImg, setSele
   const [error, setError] = useState(null)
   const { currentUser } = useAuth()
   const [canDelete, setCanDelete] = useState(false)
-  const date = new Date(imgData.createdAt.seconds * 1000)
-  const newdate = date.toLocaleString(DateTime.DATE_MED)
-  const finaldate = newdate.substring(0, 12)
+  const date = DateTime.fromSeconds(imgData.createdAt.seconds)
+  const newDate = date.setLocale('en')
+  const finaldate = newDate.toLocaleString(DateTime.DATE_MED)
   let userid
 
   if (currentUser) {


### PR DESCRIPTION
Gallery modal date is now set to locale 'en' on all devices, for consistency.  
Fixes #2: Gallery modal dates broken (clipping)  

Solution implemented based on discussion in issue #2, as suggested by @SLorant.  

Changes: 
- Set date locale to 'en' in Modal.jsx using Luxon's DateTime library.

Corrected date UI:
![image](https://user-images.githubusercontent.com/90817905/230801861-f1f36b14-26a1-428e-8d4d-9b8ceadc8a34.png)
