### PR TITLE
Fixed white bg on bottom of gallery page while photos loading

### DIFF
--- a/src/components/gallerycomp/Gallery.jsx
+++ b/src/components/gallerycomp/Gallery.jsx
@@ -40,7 +40,7 @@ const Gallery = () => {
     }, 1000)
   }, [])
   return (
-    <div className="h-full w-full dark:bg-darkblue">
+    <div className="h-full min-h-screen w-full dark:bg-darkblue">
       <Helmet>
         <title>Huskies' Gallery</title>
         <meta property="og:title" content="Snowy Snaps - Huskies' Gallery" />

--- a/src/components/profilecomp/mysnaps/MySnaps.jsx
+++ b/src/components/profilecomp/mysnaps/MySnaps.jsx
@@ -51,7 +51,7 @@ const MySnaps = () => {
   LoadMySnaps(setUser, setCanUpload)
 
   return (
-    <div className="h-full w-full dark:bg-darkblue">
+    <div className="h-full min-h-screen w-full dark:bg-darkblue">
       <Helmet>
         <title>Snaps</title>
         <meta property="og:title" content="Snowy Snaps - Your Snaps" />


### PR DESCRIPTION
Applied min-h-screen to gallery and mysnaps pages to ensure page bg fills the entire viewport height.  
Fixes #3: Bottom of Gallery page is white when photos are loading (in dark theme)  

Note: I noticed while implementing that the same issue was occurring in the mysnaps component (for profile galleries), so I implemented the fix for that component as well.