### PR TITLE
Implemented loading animation and loading logic for Gallery pages

### DIFF
--- a/src/components/LoadingSpinner.jsx
+++ b/src/components/LoadingSpinner.jsx
@@ -1,0 +1,30 @@
+import React from "react";
+import { motion } from "framer-motion";
+
+const LoadingSpinner = () => {
+  const spinnerImg = "/assets/emojis/silly.png";
+
+  const spinVariants = {
+    animate: {
+      rotate: [0, 225, 360],
+      transition: {
+        duration: 1,
+        repeat: Infinity,
+      },
+    },
+  };
+
+  return (
+    <div className="flex h-full items-center justify-center">
+      <motion.img
+        src={spinnerImg}
+        alt="Loading spinner"
+        variants={spinVariants}
+        animate="animate"
+        className="my-4 h-24 w-24"
+      />
+    </div>
+  );
+};
+
+export default LoadingSpinner;

--- a/src/components/gallerycomp/Gallery.jsx
+++ b/src/components/gallerycomp/Gallery.jsx
@@ -8,6 +8,7 @@ import { Helmet } from 'react-helmet-async'
 import { lazy, Suspense } from 'react'
 const Modal = lazy(() => import('./Modal'))
 const ImageGrid = lazy(() => import('./ImageGrid'))
+import LoadingSpinner from '../LoadingSpinner'
 
 const Gallery = () => {
   const [selectedImg, setSelectedImg] = useState(null)
@@ -34,11 +35,6 @@ const Gallery = () => {
     emotion3: '',
     createdAt: '',
   })
-  useEffect(() => {
-    setTimeout(() => {
-      setLoading(false)
-    }, 1000)
-  }, [])
   return (
     <div className="h-full w-full dark:bg-darkblue">
       <Helmet>
@@ -62,8 +58,8 @@ const Gallery = () => {
         />
         <UploadSnap file={file} setFile={setFile} setIsUploaded={setIsUploaded} />
       </div>
-      {!loading && (
-        <Suspense fallback={<div>Loading...</div>}>
+        {loading && <LoadingSpinner />}
+        <Suspense fallback={<LoadingSpinner />} >
           <ImageGrid
             imgData={imgData}
             isUploaded={isUploaded}
@@ -73,12 +69,12 @@ const Gallery = () => {
             order={order}
             emotionArray={emotionArray}
             imgType={imgType}
+            onLoaded={() => setLoading(false)}
           />
         </Suspense>
-      )}
       <div className=" h-60 w-full dark:bg-darkblue"></div>
       {selectedImg && (
-        <Suspense fallback={<div>Loading...</div>}>
+        <Suspense fallback={<LoadingSpinner />}>
           <Modal
             emotions={emotions}
             imgData={imgData}

--- a/src/components/gallerycomp/ImageGrid.jsx
+++ b/src/components/gallerycomp/ImageGrid.jsx
@@ -1,9 +1,39 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import useFirestore from '../hooks/useFirestore'
 import { motion } from 'framer-motion'
 
-const ImageGrid = ({ setSelectedImg, order, emotionArray, imgType, isUploaded, setIsUploaded, setImgData }) => {
+const ImageGrid = ({ setSelectedImg, order, emotionArray, imgType, isUploaded, setIsUploaded, setImgData, onLoaded }) => {
   const { docs } = useFirestore('images', undefined, isUploaded, setIsUploaded, order, emotionArray, imgType)
+  
+  // Loading logic: event listener for each image, when all images are loaded, call onLoaded() to set loading to false
+  useEffect(() => {
+    if (docs && docs.length > 0 && onLoaded) {
+      const images = document.querySelectorAll('.motion-image')
+      let loadedCount = 0
+
+      const handleImageLoaded = () => {
+        loadedCount++
+
+        if (loadedCount === images.length) {
+          onLoaded()
+        }
+      }
+
+      images.forEach((image) => {
+        if (image.complete) {
+          handleImageLoaded()
+        } else {
+          image.addEventListener('load', handleImageLoaded)
+        }
+      })
+
+      return () => {
+        images.forEach((image) => {
+          image.removeEventListener('load', handleImageLoaded)
+        })
+      }
+    }
+  }, [docs, onLoaded])
 
   return (
     <div className="  ">
@@ -28,7 +58,7 @@ const ImageGrid = ({ setSelectedImg, order, emotionArray, imgType, isUploaded, s
                 }}>
                 <motion.img
                   src={doc.url}
-                  className="h-full w-full rounded-lg object-cover opacity-80 hover:opacity-100"
+                  className="motion-image h-full w-full rounded-lg object-cover opacity-80 hover:opacity-100"
                   loading="lazy"
                   alt="huskypic"
                   initial={{ opacity: 0 }}

--- a/src/components/hooks/useFirestore.jsx
+++ b/src/components/hooks/useFirestore.jsx
@@ -17,11 +17,11 @@ const useFirestore = (imageCollection, userID, isUploaded, setIsUploaded, upload
         orderBy('createdAt', 'desc'),
       )
     // If there are no emotions and no image type specified, query for all images sorted by upload date
-    else if (!emotionArray.length && imgType === '') {
+    else if (!emotionArray?.length && imgType === '') {
       q = query(collection(projectFirestore, imageCollection), orderBy('createdAt', uploadDate))
     }
     // If there are no emotions specified but an image type is specified, query for images that match the image type
-    else if (!emotionArray.length) {
+    else if (!emotionArray?.length) {
       q = query(
         collection(projectFirestore, imageCollection),
         where('gif', '==', isGif),
@@ -29,7 +29,7 @@ const useFirestore = (imageCollection, userID, isUploaded, setIsUploaded, upload
       )
     }
     // If there are emotions specified but no image type specified, query for images that match any of the emotions
-    else if (emotionArray.length && imgType === '') {
+    else if (emotionArray?.length && imgType === '') {
       q = query(
         collection(projectFirestore, imageCollection),
         where('emotion', 'in', emotionArray),

--- a/src/components/profilecomp/mysnaps/LikedSnaps.jsx
+++ b/src/components/profilecomp/mysnaps/LikedSnaps.jsx
@@ -1,8 +1,39 @@
+import React, { useEffect } from 'react'
 import { motion } from 'framer-motion'
 import useShowLiked from '../../hooks/useShowLiked'
 
-const LikedSnaps = ({ userID, setSelectedImg, setImgData }) => {
+const LikedSnaps = ({ userID, setSelectedImg, setImgData, onLoaded }) => {
   const { docs } = useShowLiked(userID)
+
+  // Loading logic: event listener for each image, when all images are loaded, call onLoaded() to set loading to false
+  useEffect(() => {
+    if (docs && docs.length > 0 && onLoaded) {
+      const images = document.querySelectorAll('.motion-image')
+      let loadedCount = 0
+
+      const handleImageLoaded = () => {
+        loadedCount++
+
+        if (loadedCount === images.length) {
+          onLoaded()
+        }
+      }
+
+      images.forEach((image) => {
+        if (image.complete) {
+          handleImageLoaded()
+        } else {
+          image.addEventListener('load', handleImageLoaded)
+        }
+      })
+
+      return () => {
+        images.forEach((image) => {
+          image.removeEventListener('load', handleImageLoaded)
+        })
+      }
+    }
+  }, [docs, onLoaded])
 
   return (
     <div className=" h-full">
@@ -27,7 +58,7 @@ const LikedSnaps = ({ userID, setSelectedImg, setImgData }) => {
                 }}>
                 <motion.img
                   src={doc.url}
-                  className="h-full w-full rounded-lg object-cover opacity-80 hover:opacity-100"
+                  className="motion-image h-full w-full rounded-lg object-cover opacity-80 hover:opacity-100"
                   loading="lazy"
                   alt="huskypic"
                   initial={{ opacity: 0 }}

--- a/src/components/profilecomp/mysnaps/MySnaps.jsx
+++ b/src/components/profilecomp/mysnaps/MySnaps.jsx
@@ -9,6 +9,7 @@ import LikedSnaps from './LikedSnaps'
 import { Link } from 'react-router-dom'
 import LoadMySnaps from './LoadMySnaps'
 import { Helmet } from 'react-helmet-async'
+import LoadingSpinner from '../../LoadingSpinner'
 
 const MySnaps = () => {
   const [selectedImg, setSelectedImg] = useState(null)
@@ -43,11 +44,6 @@ const MySnaps = () => {
     [{ label: 'sad' }, { src: '/assets/emojis/sad.png' }],
   ]
 
-  useEffect(() => {
-    setTimeout(() => {
-      setLoading(false)
-    }, 1000)
-  }, [])
   LoadMySnaps(setUser, setCanUpload)
 
   return (
@@ -80,17 +76,25 @@ const MySnaps = () => {
           </Link>
         </div>
       </div>
-      {!loading && !likedImages && (
+      {loading && <LoadingSpinner />}
+      {!likedImages && (
         <UploadedSnaps
           userID={user.userID}
           isUploaded={isUploaded}
           setIsUploaded={setIsUploaded}
           setImgData={setImgData}
           setSelectedImg={setSelectedImg}
+          onLoaded={() => setLoading(false)}
         />
       )}
-      {!loading && likedImages && (
-        <LikedSnaps userID={user.userID} imgData={imgData} setImgData={setImgData} setSelectedImg={setSelectedImg} />
+      {likedImages && (
+        <LikedSnaps 
+          userID={user.userID} 
+          imgData={imgData} 
+          setImgData={setImgData} 
+          setSelectedImg={setSelectedImg} 
+          onLoaded={() => setLoading(false)} 
+        />
       )}
       <div className=" h-60 w-full dark:bg-darkblue"></div>
       {selectedImg && (

--- a/src/components/profilecomp/mysnaps/UploadedSnaps.jsx
+++ b/src/components/profilecomp/mysnaps/UploadedSnaps.jsx
@@ -1,8 +1,39 @@
+import React, { useEffect } from 'react'
 import { motion } from 'framer-motion'
 import useFirestore from '../../hooks/useFirestore'
 
-const UploadedSnaps = ({ setSelectedImg, setImgData, userID, isUploaded, setIsUploaded }) => {
+const UploadedSnaps = ({ setSelectedImg, setImgData, userID, isUploaded, setIsUploaded, onLoaded }) => {
   const { docs } = useFirestore('images', userID, isUploaded, setIsUploaded)
+
+  // Loading logic: event listener for each image, when all images are loaded, call onLoaded() to set loading to false
+  useEffect(() => {
+    if (docs && docs.length > 0 && onLoaded) {
+      const images = document.querySelectorAll('.motion-image')
+      let loadedCount = 0
+
+      const handleImageLoaded = () => {
+        loadedCount++
+
+        if (loadedCount === images.length) {
+          onLoaded()
+        }
+      }
+
+      images.forEach((image) => {
+        if (image.complete) {
+          handleImageLoaded()
+        } else {
+          image.addEventListener('load', handleImageLoaded)
+        }
+      })
+
+      return () => {
+        images.forEach((image) => {
+          image.removeEventListener('load', handleImageLoaded)
+        })
+      }
+    }
+  }, [docs, onLoaded])
 
   return (
     <div className=" h-full">
@@ -27,7 +58,7 @@ const UploadedSnaps = ({ setSelectedImg, setImgData, userID, isUploaded, setIsUp
                 }}>
                 <motion.img
                   src={doc.url}
-                  className="h-full w-full rounded-lg object-cover opacity-80 hover:opacity-100"
+                  className="motion-image h-full w-full rounded-lg object-cover opacity-80 hover:opacity-100"
                   loading="lazy"
                   alt="huskypic"
                   initial={{ opacity: 0 }}


### PR DESCRIPTION
Fixes #4: Add loading animation to Gallery page  
Changes:
- Implemented loading spinner component 
  - I wasn't sure how to style it, so I used one of the husky emojis as a placeholder. Pretty happy with how it came out though 😂  
- Implemented loading logic for the gallery and profile gallery pages
  - Passed an `onLoaded` callback to the ImageGrid component to set `loading` to false when images have loaded
  - Removed the `useEffect` timeout loading implementation, so `ImageGrid`, `UploadedSnaps`, and `LikedImages` components are all mounted while loading (when loading is complete, the `onLoaded` callback is used to remove the loading animation)

Note that loading animation currently doesn't appear for the "liked" section, because a single loading variable is shared between uploaded and liked snaps. May want to revise the loading state handler later to take that into account on profile pages (e.g. make `uploadsLoading` and `likesLoading` as separate states).  

I also revised the `useFirestore` hook to fix a TypeError that occurred because 'length' was being read before emotionArray had loaded (this was occurring because `UploadedSnaps` and `LikedImages` now mount before photos have loaded, since I removed the 1s timeout loading logic)